### PR TITLE
feat: add rust controllers for banners and modals

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tokio",
  "url",
  "urlencoding",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0"
 dioxus = { version = "0.4", features = ["hooks", "macro"] }
 dioxus-ssr = "0.4"
 urlencoding = "2.1"
+tokio = { version = "1", features = ["sync"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/controllers/banners.rs
+++ b/src-tauri/src/controllers/banners.rs
@@ -1,0 +1,97 @@
+use std::sync::{atomic::{AtomicUsize, Ordering}, Mutex, OnceLock};
+use tokio::sync::watch;
+use dioxus::prelude::*;
+
+#[derive(Clone)]
+pub enum BannerType {
+    Offline,
+}
+
+#[derive(Clone)]
+pub struct Banner {
+    pub key: usize,
+    pub banner_type: BannerType,
+}
+
+pub struct BannerController {
+    stack: Mutex<Vec<Banner>>,
+    tx: watch::Sender<Vec<Banner>>,
+    counter: AtomicUsize,
+}
+
+impl BannerController {
+    fn new() -> Self {
+        let (tx, _rx) = watch::channel(Vec::new());
+        Self { stack: Mutex::new(Vec::new()), tx, counter: AtomicUsize::new(0) }
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<Vec<Banner>> {
+        self.tx.subscribe()
+    }
+
+    fn notify(&self) {
+        let stack = self.stack.lock().unwrap().clone();
+        let _ = self.tx.send(stack);
+    }
+
+    pub fn push(&self, banner_type: BannerType) {
+        let key = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut stack = self.stack.lock().unwrap();
+        stack.push(Banner { key, banner_type });
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn pop(&self) {
+        let mut stack = self.stack.lock().unwrap();
+        stack.pop();
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn remove(&self, key: usize) {
+        let mut stack = self.stack.lock().unwrap();
+        stack.retain(|b| b.key != key);
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn clear(&self) {
+        self.stack.lock().unwrap().clear();
+        self.notify();
+    }
+}
+
+static BANNER_CONTROLLER: OnceLock<BannerController> = OnceLock::new();
+
+pub fn banner_controller() -> &'static BannerController {
+    BANNER_CONTROLLER.get_or_init(|| BannerController::new())
+}
+
+pub fn BannerRenderer(cx: Scope) -> Element {
+    let banners = use_state(cx, || Vec::<Banner>::new());
+    use_future(cx, (), |_| {
+        to_owned![banners];
+        async move {
+            let mut rx = banner_controller().subscribe();
+            loop {
+                if rx.changed().await.is_ok() {
+                    banners.set((*rx.borrow()).clone());
+                } else {
+                    break;
+                }
+            }
+        }
+    });
+
+    cx.render(rsx! {
+        div {
+            class: "banner-container",
+            for banner in banners.get().iter() {
+                match banner.banner_type {
+                    BannerType::Offline => rsx!(div { key: "{banner.key}", "Offline" }),
+                }
+            }
+        }
+    })
+}

--- a/src-tauri/src/controllers/mod.rs
+++ b/src-tauri/src/controllers/mod.rs
@@ -1,0 +1,5 @@
+pub mod banners;
+pub mod modals;
+
+pub use banners::{banner_controller, BannerRenderer, BannerType};
+pub use modals::{modal_controller, ModalRenderer};

--- a/src-tauri/src/controllers/modals.rs
+++ b/src-tauri/src/controllers/modals.rs
@@ -1,0 +1,90 @@
+use std::sync::{atomic::{AtomicUsize, Ordering}, Mutex, OnceLock};
+use tokio::sync::watch;
+use dioxus::prelude::*;
+
+#[derive(Clone)]
+pub struct Modal {
+    pub key: usize,
+    pub modal_type: String,
+}
+
+pub struct ModalController {
+    stack: Mutex<Vec<Modal>>,
+    tx: watch::Sender<Vec<Modal>>,
+    counter: AtomicUsize,
+}
+
+impl ModalController {
+    fn new() -> Self {
+        let (tx, _rx) = watch::channel(Vec::new());
+        Self { stack: Mutex::new(Vec::new()), tx, counter: AtomicUsize::new(0) }
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<Vec<Modal>> {
+        self.tx.subscribe()
+    }
+
+    fn notify(&self) {
+        let stack = self.stack.lock().unwrap().clone();
+        let _ = self.tx.send(stack);
+    }
+
+    pub fn push(&self, modal_type: impl Into<String>) {
+        let key = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut stack = self.stack.lock().unwrap();
+        stack.push(Modal { key, modal_type: modal_type.into() });
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn pop(&self) {
+        let mut stack = self.stack.lock().unwrap();
+        stack.pop();
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn remove(&self, key: usize) {
+        let mut stack = self.stack.lock().unwrap();
+        stack.retain(|m| m.key != key);
+        drop(stack);
+        self.notify();
+    }
+
+    pub fn clear(&self) {
+        self.stack.lock().unwrap().clear();
+        self.notify();
+    }
+}
+
+static MODAL_CONTROLLER: OnceLock<ModalController> = OnceLock::new();
+
+pub fn modal_controller() -> &'static ModalController {
+    MODAL_CONTROLLER.get_or_init(|| ModalController::new())
+}
+
+pub fn ModalRenderer(cx: Scope) -> Element {
+    let modals = use_state(cx, || Vec::<Modal>::new());
+    use_future(cx, (), |_| {
+        to_owned![modals];
+        async move {
+            let mut rx = modal_controller().subscribe();
+            loop {
+                if rx.changed().await.is_ok() {
+                    modals.set((*rx.borrow()).clone());
+                } else {
+                    break;
+                }
+            }
+        }
+    });
+
+    cx.render(rsx! {
+        div {
+            class: "modal-container",
+            for modal in modals.get().iter() {
+                div { key: "{modal.key}", class: "modal", {modal.modal_type.clone()} }
+            }
+        }
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_log::{Target, TargetKind, WEBVIEW_TARGET};
 use tauri_plugin_notification::NotificationExt;
 
+pub mod controllers;
+
 #[cfg(desktop)]
 mod tray;
 mod updater;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod controllers;
 mod ui;
 
 fn main() {

--- a/src-tauri/src/ui/app.rs
+++ b/src-tauri/src/ui/app.rs
@@ -2,10 +2,13 @@ use dioxus::prelude::*;
 
 use super::components::{ErrorBoundary, Loader};
 use super::pages::AppPage;
+use crate::controllers::{BannerRenderer, ModalRenderer};
 
 pub fn App(cx: Scope) -> Element {
     cx.render(rsx! {
         ErrorBoundary {}
+        BannerRenderer {}
+        ModalRenderer {}
         Loader {}
         AppPage {}
     })


### PR DESCRIPTION
## Summary
- add banner and modal controllers in Rust using watch channels
- expose renderers for banners and modals to Dioxus UI
- wire controllers into app and add tokio sync dependency

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5516e8bd08329be7f45934ff0bfe9