### PR TITLE
feat: scaffold rust stores and objects

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use tauri_plugin_log::{Target, TargetKind, WEBVIEW_TARGET};
 use tauri_plugin_notification::NotificationExt;
 
 pub mod controllers;
+pub mod stores;
 
 #[cfg(desktop)]
 mod tray;

--- a/src-tauri/src/stores/account_store.rs
+++ b/src-tauri/src/stores/account_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AccountStoreState {
+    // TODO: replicate fields from TypeScript AccountStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum AccountStoreEvent {
+    Updated,
+}
+
+pub type AccountStore = Store<AccountStoreState, AccountStoreEvent>;

--- a/src-tauri/src/stores/app_store.rs
+++ b/src-tauri/src/stores/app_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppStoreState {
+    // TODO: replicate fields from TypeScript AppStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum AppStoreEvent {
+    Updated,
+}
+
+pub type AppStore = Store<AppStoreState, AppStoreEvent>;

--- a/src-tauri/src/stores/channel_store.rs
+++ b/src-tauri/src/stores/channel_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ChannelStoreState {
+    // TODO: replicate fields from TypeScript ChannelStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum ChannelStoreEvent {
+    Updated,
+}
+
+pub type ChannelStore = Store<ChannelStoreState, ChannelStoreEvent>;

--- a/src-tauri/src/stores/emoji_store.rs
+++ b/src-tauri/src/stores/emoji_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EmojiStoreState {
+    // TODO: replicate fields from TypeScript EmojiStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum EmojiStoreEvent {
+    Updated,
+}
+
+pub type EmojiStore = Store<EmojiStoreState, EmojiStoreEvent>;

--- a/src-tauri/src/stores/experiments_store.rs
+++ b/src-tauri/src/stores/experiments_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExperimentsStoreState {
+    // TODO: replicate fields from TypeScript ExperimentsStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum ExperimentsStoreEvent {
+    Updated,
+}
+
+pub type ExperimentsStore = Store<ExperimentsStoreState, ExperimentsStoreEvent>;

--- a/src-tauri/src/stores/gateway_connection_store.rs
+++ b/src-tauri/src/stores/gateway_connection_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GatewayConnectionStoreState {
+    // TODO: replicate fields from TypeScript GatewayConnectionStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum GatewayConnectionStoreEvent {
+    Updated,
+}
+
+pub type GatewayConnectionStore = Store<GatewayConnectionStoreState, GatewayConnectionStoreEvent>;

--- a/src-tauri/src/stores/guild_member_list_store.rs
+++ b/src-tauri/src/stores/guild_member_list_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GuildMemberListStoreState {
+    // TODO: replicate fields from TypeScript GuildMemberListStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum GuildMemberListStoreEvent {
+    Updated,
+}
+
+pub type GuildMemberListStore = Store<GuildMemberListStoreState, GuildMemberListStoreEvent>;

--- a/src-tauri/src/stores/guild_member_store.rs
+++ b/src-tauri/src/stores/guild_member_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GuildMemberStoreState {
+    // TODO: replicate fields from TypeScript GuildMemberStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum GuildMemberStoreEvent {
+    Updated,
+}
+
+pub type GuildMemberStore = Store<GuildMemberStoreState, GuildMemberStoreEvent>;

--- a/src-tauri/src/stores/guild_store.rs
+++ b/src-tauri/src/stores/guild_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GuildStoreState {
+    // TODO: replicate fields from TypeScript GuildStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum GuildStoreEvent {
+    Updated,
+}
+
+pub type GuildStore = Store<GuildStoreState, GuildStoreEvent>;

--- a/src-tauri/src/stores/message_queue.rs
+++ b/src-tauri/src/stores/message_queue.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MessageQueueState {
+    // TODO: replicate fields from TypeScript MessageQueue.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageQueueEvent {
+    Updated,
+}
+
+pub type MessageQueue = Store<MessageQueueState, MessageQueueEvent>;

--- a/src-tauri/src/stores/message_store.rs
+++ b/src-tauri/src/stores/message_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MessageStoreState {
+    // TODO: replicate fields from TypeScript MessageStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageStoreEvent {
+    Updated,
+}
+
+pub type MessageStore = Store<MessageStoreState, MessageStoreEvent>;

--- a/src-tauri/src/stores/mod.rs
+++ b/src-tauri/src/stores/mod.rs
@@ -1,0 +1,26 @@
+pub mod store;
+
+// Individual store modules generated from the TypeScript MobX stores.
+// Each store exposes a `State` struct, an `Event` enum and a type alias
+// `<Name>Store` which wraps the generic [`Store`] type.
+
+pub mod account_store;
+pub mod app_store;
+pub mod channel_store;
+pub mod emoji_store;
+pub mod experiments_store;
+pub mod gateway_connection_store;
+pub mod guild_member_list_store;
+pub mod guild_member_store;
+pub mod guild_store;
+pub mod message_queue;
+pub mod message_store;
+pub mod presence_store;
+pub mod private_channel_store;
+pub mod read_state_store;
+pub mod role_store;
+pub mod theme_store;
+pub mod updater_store;
+pub mod user_store;
+
+pub mod objects;

--- a/src-tauri/src/stores/objects/channel.rs
+++ b/src-tauri/src/stores/objects/channel.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Channel {
+    // TODO: fields from TypeScript Channel.ts
+}

--- a/src-tauri/src/stores/objects/emoji.rs
+++ b/src-tauri/src/stores/objects/emoji.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Emoji {
+    // TODO: fields from TypeScript Emoji.ts
+}

--- a/src-tauri/src/stores/objects/guild.rs
+++ b/src-tauri/src/stores/objects/guild.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Guild {
+    // TODO: fields from TypeScript Guild.ts
+}

--- a/src-tauri/src/stores/objects/guild_member.rs
+++ b/src-tauri/src/stores/objects/guild_member.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GuildMember {
+    // TODO: fields from TypeScript GuildMember.ts
+}

--- a/src-tauri/src/stores/objects/message.rs
+++ b/src-tauri/src/stores/objects/message.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Message {
+    // TODO: fields from TypeScript Message.ts
+}

--- a/src-tauri/src/stores/objects/message_base.rs
+++ b/src-tauri/src/stores/objects/message_base.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MessageBase {
+    // TODO: fields from TypeScript MessageBase.ts
+}

--- a/src-tauri/src/stores/objects/mod.rs
+++ b/src-tauri/src/stores/objects/mod.rs
@@ -1,0 +1,11 @@
+pub mod channel;
+pub mod emoji;
+pub mod guild;
+pub mod guild_member;
+pub mod message;
+pub mod message_base;
+pub mod presence;
+pub mod queued_message;
+pub mod read_state;
+pub mod role;
+pub mod user;

--- a/src-tauri/src/stores/objects/presence.rs
+++ b/src-tauri/src/stores/objects/presence.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Presence {
+    // TODO: fields from TypeScript Presence.ts
+}

--- a/src-tauri/src/stores/objects/queued_message.rs
+++ b/src-tauri/src/stores/objects/queued_message.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct QueuedMessage {
+    // TODO: fields from TypeScript QueuedMessage.ts
+}

--- a/src-tauri/src/stores/objects/read_state.rs
+++ b/src-tauri/src/stores/objects/read_state.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReadState {
+    // TODO: fields from TypeScript ReadState.ts
+}

--- a/src-tauri/src/stores/objects/role.rs
+++ b/src-tauri/src/stores/objects/role.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Role {
+    // TODO: fields from TypeScript Role.ts
+}

--- a/src-tauri/src/stores/objects/user.rs
+++ b/src-tauri/src/stores/objects/user.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct User {
+    // TODO: fields from TypeScript User.ts
+}

--- a/src-tauri/src/stores/presence_store.rs
+++ b/src-tauri/src/stores/presence_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PresenceStoreState {
+    // TODO: replicate fields from TypeScript PresenceStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum PresenceStoreEvent {
+    Updated,
+}
+
+pub type PresenceStore = Store<PresenceStoreState, PresenceStoreEvent>;

--- a/src-tauri/src/stores/private_channel_store.rs
+++ b/src-tauri/src/stores/private_channel_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PrivateChannelStoreState {
+    // TODO: replicate fields from TypeScript PrivateChannelStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum PrivateChannelStoreEvent {
+    Updated,
+}
+
+pub type PrivateChannelStore = Store<PrivateChannelStoreState, PrivateChannelStoreEvent>;

--- a/src-tauri/src/stores/read_state_store.rs
+++ b/src-tauri/src/stores/read_state_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReadStateStoreState {
+    // TODO: replicate fields from TypeScript ReadStateStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum ReadStateStoreEvent {
+    Updated,
+}
+
+pub type ReadStateStore = Store<ReadStateStoreState, ReadStateStoreEvent>;

--- a/src-tauri/src/stores/role_store.rs
+++ b/src-tauri/src/stores/role_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RoleStoreState {
+    // TODO: replicate fields from TypeScript RoleStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum RoleStoreEvent {
+    Updated,
+}
+
+pub type RoleStore = Store<RoleStoreState, RoleStoreEvent>;

--- a/src-tauri/src/stores/store.rs
+++ b/src-tauri/src/stores/store.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+use tokio::sync::{broadcast, Mutex};
+
+/// Generic observable store backed by an [`Arc<Mutex<_>>`] state and a broadcast channel.
+///
+/// Each store holds its state inside a [`Mutex`] so it can be shared across
+/// asynchronous tasks.  When the state is mutated an event can be sent through
+/// the broadcast channel allowing other parts of the application to react to
+/// the update.
+pub struct Store<S, E> {
+    pub state: Arc<Mutex<S>>,           // shared mutable state
+    pub tx: broadcast::Sender<E>,       // event broadcaster
+}
+
+impl<S: Default, E: Clone> Store<S, E> {
+    /// Creates a new store and returns it along with a receiver for events.
+    pub fn new() -> (Self, broadcast::Receiver<E>) {
+        let (tx, rx) = broadcast::channel(32);
+        (
+            Self {
+                state: Arc::new(Mutex::new(S::default())),
+                tx,
+            },
+            rx,
+        )
+    }
+}

--- a/src-tauri/src/stores/theme_store.rs
+++ b/src-tauri/src/stores/theme_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ThemeStoreState {
+    // TODO: replicate fields from TypeScript ThemeStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum ThemeStoreEvent {
+    Updated,
+}
+
+pub type ThemeStore = Store<ThemeStoreState, ThemeStoreEvent>;

--- a/src-tauri/src/stores/updater_store.rs
+++ b/src-tauri/src/stores/updater_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UpdaterStoreState {
+    // TODO: replicate fields from TypeScript UpdaterStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum UpdaterStoreEvent {
+    Updated,
+}
+
+pub type UpdaterStore = Store<UpdaterStoreState, UpdaterStoreEvent>;

--- a/src-tauri/src/stores/user_store.rs
+++ b/src-tauri/src/stores/user_store.rs
@@ -1,0 +1,15 @@
+use super::store::Store;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserStoreState {
+    // TODO: replicate fields from TypeScript UserStore.ts
+}
+
+#[derive(Debug, Clone)]
+pub enum UserStoreEvent {
+    Updated,
+}
+
+pub type UserStore = Store<UserStoreState, UserStoreEvent>;


### PR DESCRIPTION
## Summary
- add Rust store scaffolding mirroring TS MobX stores
- introduce placeholder Rust object models
- expose stores module in Tauri lib

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_b_68b559e2259c83298e0568e59f5805fa