### PR TITLE
feat(net): add REST and gateway clients

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "chrono",
  "dioxus",
  "dioxus-ssr",
+ "futures-util",
  "log",
  "reqwest",
  "serde",
@@ -123,6 +124,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
+ "tokio-tungstenite",
  "url",
  "urlencoding",
 ]
@@ -948,6 +950,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deranged"
@@ -2662,6 +2670,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,6 +3838,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5128,6 +5147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5316,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.64",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5347,6 +5397,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,8 +26,9 @@ tauri-plugin-notification = "2.2.2"
 tauri-plugin-single-instance = "2.0.1"
 tauri-plugin-autostart = "2.2.0"
 reqwest = { version = "0.12.12", default-features = false, features = [
-	"json",
-	"rustls-tls",
+        "json",
+        "rustls-tls",
+        "multipart",
 ] }
 url = "2.5.4"
 chrono = "0.4"
@@ -37,7 +38,9 @@ serde_json = "1.0"
 dioxus = { version = "0.4", features = ["hooks", "macro"] }
 dioxus-ssr = "0.4"
 urlencoding = "2.1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "net", "time"] }
+tokio-tungstenite = "0.21"
+futures-util = "0.3"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri_plugin_notification::NotificationExt;
 
 pub mod controllers;
 pub mod stores;
+pub mod net;
 
 #[cfg(desktop)]
 mod tray;

--- a/src-tauri/src/net/gateway.rs
+++ b/src-tauri/src/net/gateway.rs
@@ -1,0 +1,105 @@
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::time::{sleep, Duration};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::{Message, protocol::frame::coding::CloseCode};
+use url::Url;
+
+use log::{debug, info, warn};
+
+/// Simple gateway client using a WebSocket connection.
+/// Handles authentication and basic reconnection logic.
+pub struct Gateway {
+    url: Url,
+    token: String,
+    reconnect_delay: Duration,
+}
+
+impl Gateway {
+    pub fn new(url: Url, token: String) -> Self {
+        Self { url, token, reconnect_delay: Duration::from_secs(10) }
+    }
+
+    /// Start the gateway connection. This will keep trying to reconnect
+    /// until an authentication failure occurs.
+    pub async fn start(&mut self) {
+        loop {
+            match self.connect_once().await {
+                Ok(reconnect) => {
+                    if !reconnect {
+                        break;
+                    }
+                    warn!(
+                        "gateway closed; reconnecting in {:?}",
+                        self.reconnect_delay
+                    );
+                    sleep(self.reconnect_delay).await;
+                    self.reconnect_delay *= 2;
+                }
+                Err(e) => {
+                    warn!(
+                        "gateway error: {:?}; reconnecting in {:?}",
+                        e,
+                        self.reconnect_delay
+                    );
+                    sleep(self.reconnect_delay).await;
+                    self.reconnect_delay *= 2;
+                }
+            }
+        }
+    }
+
+    /// Connects once to the gateway. Returns Ok(true) if the connection
+    /// should be retried, Ok(false) if it should stop (e.g. auth failure).
+    async fn connect_once(&self) -> Result<bool, tokio_tungstenite::tungstenite::Error> {
+        let url = self.url.clone();
+        info!("connecting to {}", url);
+        let (ws_stream, _) = connect_async(url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        // send identify payload
+        let identify = json!({
+            "op": 2,
+            "d": {
+                "token": self.token,
+                "capabilities": 16381,
+                "properties": {
+                    "browser": "Spacebar Tauri",
+                    "client_build_number": 0,
+                    "release_channel": "dev",
+                    "browser_user_agent": "",
+                },
+                "compress": false,
+                "presence": {
+                    "status": "online",
+                    "since": 0,
+                    "activities": [],
+                    "afk": false,
+                }
+            }
+        });
+        write.send(Message::Text(identify.to_string())).await?;
+
+        let mut should_reconnect = true;
+        while let Some(msg) = read.next().await {
+            match msg? {
+                Message::Text(text) => {
+                    debug!("gateway -> {}", text);
+                }
+                Message::Close(frame) => {
+                    if let Some(frame) = frame {
+                        if frame.code == CloseCode::Library(4004) {
+                            // authentication failed, do not reconnect
+                            warn!("gateway authentication failed");
+                            should_reconnect = false;
+                        }
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(should_reconnect)
+    }
+}

--- a/src-tauri/src/net/mod.rs
+++ b/src-tauri/src/net/mod.rs
@@ -1,0 +1,2 @@
+pub mod rest;
+pub mod gateway;

--- a/src-tauri/src/net/rest.rs
+++ b/src-tauri/src/net/rest.rs
@@ -1,0 +1,207 @@
+use reqwest::{Client, header::{HeaderMap, HeaderValue, USER_AGENT, ACCEPT}};
+use serde::{de::DeserializeOwned, Serialize, Deserialize};
+use url::Url;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteSettings {
+    pub api: String,
+    pub cdn: String,
+    pub gateway: String,
+    pub wellknown: String,
+}
+
+impl Default for RouteSettings {
+    fn default() -> Self {
+        Self {
+            api: "https://api.old.server.spacebar.chat/api".to_string(),
+            cdn: "https://cdn.old.server.spacebar.chat".to_string(),
+            gateway: "wss://gateway.old.server.spacebar.chat".to_string(),
+            wellknown: "https://spacebar.chat".to_string(),
+        }
+    }
+}
+
+fn default_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static("Spacebar-Client/1.0"));
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers
+}
+
+#[derive(Clone)]
+pub struct RestClient {
+    pub route_settings: RouteSettings,
+    client: Client,
+    headers: HeaderMap,
+}
+
+impl RestClient {
+    pub fn new(route_settings: RouteSettings) -> Self {
+        let client = Client::new();
+        let headers = default_headers();
+        Self { route_settings, client, headers }
+    }
+
+    pub fn set_token(&mut self, token: Option<&str>) {
+        if let Some(token) = token {
+            self.headers.insert(
+                "Authorization",
+                HeaderValue::from_str(token).unwrap_or_default(),
+            );
+        } else {
+            self.headers.remove("Authorization");
+        }
+    }
+
+    pub async fn get_endpoints_from_domain(url: Url) -> Result<RouteSettings, reqwest::Error> {
+        match Self::get_instance_domains(&url, &url).await {
+            Ok(settings) => Ok(settings),
+            Err(_) => {
+                let client = Client::new();
+                let well_known_url = format!("{}/.well-known/spacebar", url.origin().ascii_serialization());
+                let res: serde_json::Value = client
+                    .get(&well_known_url)
+                    .headers(default_headers())
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                let api = res["api"].as_str().unwrap_or("");
+                let api_url = Url::parse(api).unwrap();
+                Self::get_instance_domains(&api_url, &url).await
+            }
+        }
+    }
+
+    pub async fn get_instance_domains(url: &Url, knownas: &Url) -> Result<RouteSettings, reqwest::Error> {
+        let mut base = url.clone();
+        if !base.path().contains("api") {
+            base.path_segments_mut().expect("valid url").push("api");
+        }
+        let endpoint = base.join("policies/instance/domains").unwrap();
+        let client = Client::new();
+        let res: serde_json::Value = client
+            .get(endpoint)
+            .headers(default_headers())
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(RouteSettings {
+            api: res["apiEndpoint"].as_str().unwrap_or_default().to_string(),
+            gateway: res["gateway"].as_str().unwrap_or_default().to_string(),
+            cdn: res["cdn"].as_str().unwrap_or_default().to_string(),
+            wellknown: knownas.to_string(),
+        })
+    }
+
+    pub fn make_api_url(&self, path: &str, query: &[(&str, &str)]) -> Url {
+        let mut url = Url::parse(&(self.route_settings.api.clone() + path)).unwrap();
+        for (k, v) in query {
+            url.query_pairs_mut().append_pair(k, v);
+        }
+        url
+    }
+
+    pub fn make_cdn_url(&self, path: &str, query: &[(&str, &str)]) -> Url {
+        let mut url = Url::parse(&(self.route_settings.cdn.clone() + path)).unwrap();
+        for (k, v) in query {
+            url.query_pairs_mut().append_pair(k, v);
+        }
+        url
+    }
+
+    pub async fn get<T: DeserializeOwned>(&self, path: &str, query: &[(&str, &str)]) -> Result<T, reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let res = self.client.get(url).headers(self.headers.clone()).send().await?;
+        res.error_for_status()?.json::<T>().await
+    }
+
+    pub async fn post<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: Option<&B>,
+        query: &[(&str, &str)],
+        headers: &[(&str, &str)],
+    ) -> Result<T, reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let mut req = self.client.post(url).headers(self.headers.clone());
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+        let res = req.send().await?;
+        res.error_for_status()?.json::<T>().await
+    }
+
+    pub async fn put<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: Option<&B>,
+        query: &[(&str, &str)],
+        headers: &[(&str, &str)],
+    ) -> Result<T, reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let mut req = self.client.put(url).headers(self.headers.clone());
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+        let res = req.send().await?;
+        res.error_for_status()?.json::<T>().await
+    }
+
+    pub async fn patch<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: Option<&B>,
+        query: &[(&str, &str)],
+        headers: &[(&str, &str)],
+    ) -> Result<T, reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let mut req = self.client.patch(url).headers(self.headers.clone());
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+        let res = req.send().await?;
+        res.error_for_status()?.json::<T>().await
+    }
+
+    pub async fn post_form_data<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        form: reqwest::multipart::Form,
+        query: &[(&str, &str)],
+        headers: &[(&str, &str)],
+    ) -> Result<T, reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let mut req = self.client.post(url).headers(self.headers.clone()).multipart(form);
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        let res = req.send().await?;
+        res.error_for_status()?.json::<T>().await
+    }
+
+    pub async fn delete(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+        headers: &[(&str, &str)],
+    ) -> Result<(), reqwest::Error> {
+        let url = self.make_api_url(path, query);
+        let mut req = self.client.delete(url).headers(self.headers.clone());
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        req.send().await?.error_for_status()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add reqwest-based REST client with token handling
- implement tokio-tungstenite gateway with reconnection logic
- wire net module and dependencies

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5626524b08329b22c1dda04ac4093