### PR TITLE
feat: add utility modules for parsing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "dioxus-ssr",
  "futures-util",
  "log",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ urlencoding = "2.1"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "net", "time"] }
 tokio-tungstenite = "0.21"
 futures-util = "0.3"
+regex = "1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri_plugin_notification::NotificationExt;
 
 pub mod controllers;
 pub mod stores;
+pub mod utils;
 pub mod net;
 
 #[cfg(desktop)]

--- a/src-tauri/src/utils/bitfield.rs
+++ b/src-tauri/src/utils/bitfield.rs
@@ -1,0 +1,42 @@
+/// Simple bitfield helper inspired by the frontend implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BitField {
+    bits: u64,
+}
+
+impl BitField {
+    /// Creates a new bitfield from the provided bits.
+    pub fn new(bits: u64) -> Self {
+        Self { bits }
+    }
+
+    /// Checks whether any of the provided bits are set.
+    pub fn any(&self, bit: u64) -> bool {
+        self.bits & bit != 0
+    }
+
+    /// Checks whether all provided bits are set.
+    pub fn has(&self, bit: u64) -> bool {
+        self.bits & bit == bit
+    }
+
+    /// Returns the bits that are missing from the provided mask.
+    pub fn missing(&self, bits: u64) -> u64 {
+        bits & !self.bits
+    }
+
+    /// Adds bits to the bitfield.
+    pub fn add(&mut self, bits: u64) {
+        self.bits |= bits;
+    }
+
+    /// Removes bits from the bitfield.
+    pub fn remove(&mut self, bits: u64) {
+        self.bits &= !bits;
+    }
+
+    /// Returns the underlying raw value.
+    pub fn bits(&self) -> u64 {
+        self.bits
+    }
+}

--- a/src-tauri/src/utils/emoji.rs
+++ b/src-tauri/src/utils/emoji.rs
@@ -1,0 +1,46 @@
+use regex::Regex;
+
+/// Represents an emoji parsed from text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedEmoji {
+    /// A unicode emoji, stored as its unified string.
+    Unicode { unified: String },
+    /// A custom guild emoji with optional animation flag.
+    Custom { id: String, name: String, animated: bool },
+}
+
+/// A part of a parsed string, either raw text or an emoji.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmojiPart {
+    Text(String),
+    Emoji(ParsedEmoji),
+}
+
+/// Parses a string containing Discord style emojis.
+///
+/// The returned vector alternates between text and emojis, allowing consumers to
+/// reconstruct the original string or render custom emoji objects.
+pub fn parse_emoji_string(content: &str) -> Vec<EmojiPart> {
+    let regex = Regex::new(r"<(a?):(\w+):(\d+)>" ).expect("invalid regex");
+    let mut last_index = 0;
+    let mut result = Vec::new();
+
+    for captures in regex.captures_iter(content) {
+        if let Some(mat) = captures.get(0) {
+            if mat.start() > last_index {
+                result.push(EmojiPart::Text(content[last_index..mat.start()].to_string()));
+            }
+            let animated = &captures[1] == "a";
+            let name = captures[2].to_string();
+            let id = captures[3].to_string();
+            result.push(EmojiPart::Emoji(ParsedEmoji::Custom { id, name, animated }));
+            last_index = mat.end();
+        }
+    }
+
+    if last_index < content.len() {
+        result.push(EmojiPart::Text(content[last_index..].to_string()));
+    }
+
+    result
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,0 +1,4 @@
+pub mod snowflake;
+pub mod emoji;
+pub mod bitfield;
+

--- a/src-tauri/src/utils/snowflake.rs
+++ b/src-tauri/src/utils/snowflake.rs
@@ -1,0 +1,83 @@
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Discord epoch (2015-01-01T00:00:00.000Z)
+pub const EPOCH: u64 = 1420070400000;
+
+/// A generator for Discord snowflakes.
+///
+/// This structure mirrors the helper from the frontend and allows generating
+/// and deconstructing snowflakes in a platform agnostic way.
+#[derive(Debug)]
+pub struct SnowflakeGenerator {
+    worker_id: u8,
+    process_id: u8,
+    increment: AtomicU16,
+}
+
+impl SnowflakeGenerator {
+    /// Creates a new generator with the provided worker and process ids.
+    pub fn new(worker_id: u8, process_id: u8) -> Self {
+        Self {
+            worker_id: worker_id & 0x1F,
+            process_id: process_id & 0x1F,
+            increment: AtomicU16::new(0),
+        }
+    }
+
+    /// Generates a new snowflake as a `u64`.
+    pub fn generate(&self) -> u64 {
+        let time = now_millis() - EPOCH;
+        let worker = (self.worker_id as u64 & 0x1F) << 17;
+        let process = (self.process_id as u64 & 0x1F) << 12;
+        let inc = (self.increment.fetch_add(1, Ordering::Relaxed) as u64) & 0xFFF;
+        (time << 22) | worker | process | inc
+    }
+
+    /// Deconstructs an existing snowflake into its parts.
+    pub fn deconstruct(id: u64) -> DeconstructedSnowflake {
+        DeconstructedSnowflake {
+            timestamp: (id >> 22) + EPOCH,
+            worker_id: ((id & 0x3E0000) >> 17) as u8,
+            process_id: ((id & 0x1F000) >> 12) as u8,
+            increment: (id & 0xFFF) as u16,
+        }
+    }
+}
+
+/// Parts of a Discord snowflake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeconstructedSnowflake {
+    pub timestamp: u64,
+    pub worker_id: u8,
+    pub process_id: u8,
+    pub increment: u16,
+}
+
+impl DeconstructedSnowflake {
+    /// Returns the creation time of the snowflake as [`SystemTime`].
+    pub fn as_system_time(&self) -> SystemTime {
+        UNIX_EPOCH + std::time::Duration::from_millis(self.timestamp)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis() as u64
+}
+
+#[cfg(not(target_os = "windows"))]
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis() as u64
+}
+
+/// Convenience function to parse a snowflake from a decimal string.
+pub fn parse_snowflake(id: &str) -> Option<u64> {
+    id.parse::<u64>().ok()
+}


### PR DESCRIPTION
## Summary
- add platform-agnostic snowflake generator and parser
- provide emoji parsing helper and simple bitfield wrapper
- expose utils module and add regex dependency

## Testing
- `cargo test` *(fails: the trait bound `HeaderValue: Default` is not satisfied)*

------
https://chatgpt.com/codex/tasks/task_b_68b571056874832995afb55826a4d6b9