### PR TITLE
Add optional Go FFI integration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -416,6 +416,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "auto-launch"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +736,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +822,30 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1001,7 +1055,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.106",
 ]
 
@@ -2125,6 +2179,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3452,6 +3515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,7 +3807,7 @@ checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.60.2",
@@ -4820,6 +4889,7 @@ dependencies = [
 name = "spacebar-core"
 version = "0.1.0"
 dependencies = [
+ "cbindgen",
  "dioxus",
  "futures-util",
  "httpmock",
@@ -4879,6 +4949,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -5462,6 +5538,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5647,6 +5738,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/core/Cargo.toml
+++ b/src-tauri/core/Cargo.toml
@@ -3,6 +3,9 @@ name = "spacebar-core"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+with-go = []
+
 [dependencies]
 url = "2.5.4"
 log = "0.4.22"
@@ -23,3 +26,6 @@ reqwest = { version = "0.12.12", default-features = false, features = ["json", "
 
 [dev-dependencies]
 httpmock = "0.7"
+
+[build-dependencies]
+cbindgen = "0.24"

--- a/src-tauri/core/build.rs
+++ b/src-tauri/core/build.rs
@@ -1,0 +1,34 @@
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let gen_dir = PathBuf::from(&crate_dir).join("../gen");
+    std::fs::create_dir_all(&gen_dir).unwrap();
+    cbindgen::Builder::new()
+        .with_crate(&crate_dir)
+        .with_language(cbindgen::Language::C)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(gen_dir.join("spacebar_core.h"));
+
+    if env::var_os("CARGO_FEATURE_WITH_GO").is_some() {
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let lib_path = out_dir.join("libgobridge.a");
+        let go_dir = PathBuf::from(&crate_dir).join("../go");
+        let status = Command::new("go")
+            .current_dir(&go_dir)
+            .args(["build", "-buildmode=c-archive", "-o"])
+            .arg(&lib_path)
+            .status()
+            .expect("failed to build go library");
+        if !status.success() {
+            panic!("go build failed");
+        }
+        println!("cargo:rustc-link-search=native={}", out_dir.display());
+        println!("cargo:rustc-link-lib=static=gobridge");
+        println!(
+            "cargo:rerun-if-changed={}",
+            go_dir.join("bridge.go").display()
+        );
+    }
+}

--- a/src-tauri/core/src/go_support.rs
+++ b/src-tauri/core/src/go_support.rs
@@ -1,0 +1,12 @@
+#[no_mangle]
+pub extern "C" fn rust_add_one(x: i32) -> i32 {
+    x + 1
+}
+
+extern "C" {
+    fn go_add_two(x: i32) -> i32;
+}
+
+pub fn call_go_add_two(x: i32) -> i32 {
+    unsafe { go_add_two(x) }
+}

--- a/src-tauri/core/src/lib.rs
+++ b/src-tauri/core/src/lib.rs
@@ -3,8 +3,14 @@ pub mod net;
 pub mod stores;
 pub mod utils;
 
+#[cfg(feature = "with-go")]
+pub mod go_support;
+
 pub use controllers::{
     banner_controller, modal_controller, BannerRenderer, BannerType, ModalRenderer,
 };
 pub use net::{Gateway, GatewayEvent, RestClient, RestError, RouteSettings};
 pub use stores::store::Store;
+
+#[cfg(feature = "with-go")]
+pub use go_support::call_go_add_two;

--- a/src-tauri/core/tests/go_tests.rs
+++ b/src-tauri/core/tests/go_tests.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "with-go")]
+use spacebar_core::call_go_add_two;
+
+#[cfg(feature = "with-go")]
+#[test]
+fn test_go_add_two() {
+    assert_eq!(call_go_add_two(40), 42);
+}

--- a/src-tauri/gen/spacebar_core.h
+++ b/src-tauri/gen/spacebar_core.h
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Discord epoch (2015-01-01T00:00:00.000Z)
+ */
+#define EPOCH 1420070400000
+
+int32_t rust_add_one(int32_t x);
+
+extern int32_t go_add_two(int32_t x);

--- a/src-tauri/go/bridge.go
+++ b/src-tauri/go/bridge.go
@@ -1,0 +1,14 @@
+package main
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../gen
+#include "spacebar_core.h"
+*/
+import "C"
+
+//export go_add_two
+func go_add_two(x C.int) C.int {
+	return C.rust_add_one(x) + 1
+}
+
+func main() {}

--- a/src-tauri/go/go.mod
+++ b/src-tauri/go/go.mod
@@ -1,0 +1,4 @@
+module gobridge
+
+go 1.24
+


### PR DESCRIPTION
## Summary
- generate C headers for Rust core with cbindgen
- add Go module compiled as C archive and linked when `with-go` feature is enabled
- expose simple cross-language helper and test

## Testing
- `cargo check -p spacebar-core`
- `cargo check -p spacebar-core --features with-go`
- `cargo test -p spacebar-core --features with-go`


------
https://chatgpt.com/codex/tasks/task_b_68b7b349bec48329b8c2463df436826b